### PR TITLE
Add "properties" member to GeoJSON Feature.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -12,7 +12,8 @@ function convert(stream) {
                 coordinates: e.data.map(function(coord) {
                     return coord.slice().reverse();
                 })
-            }
+            },
+            properties: {}
         };
     })[0];
 }


### PR DESCRIPTION
The GeoJSON exports from this library contain features without the `properties` member. This simply adds an empty `properties` member to satisfy the GeoJSON spec. Later updates could add additional info to properties like `"activity_type": "run|ride|hike"` or `"id": "9876"`
